### PR TITLE
Correct Example To Use required_providers 

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    ksoc = {
+      source  = "ksoclabs/ksoc"
+      version = "0.0.1"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-west-2"
 }


### PR DESCRIPTION
fix: Updates example to use the correct required_providers with KSOC. This was missing and was causing `terraform init` to not work correctly. 