### PR TITLE
Update Module to Use New Format of Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_ksoc_access_key_id"></a> [ksoc\_access\_key\_id](#input\_ksoc\_access\_key\_id) | Ksoc API key | `string` | n/a | yes |
-| <a name="input_ksoc_account_id"></a> [ksoc\_account\_id](#input\_ksoc\_account\_id) | Ksoc Account Identifier | `string` | n/a | yes |
-| <a name="input_ksoc_api_url"></a> [ksoc\_api\_url](#input\_ksoc\_api\_url) | KSOC API to use when registering an account | `string` | `"https://api.ksoc.com"` | no |
 | <a name="input_ksoc_assumed_role_arn"></a> [ksoc\_assumed\_role\_arn](#input\_ksoc\_assumed\_role\_arn) | KSOC Role that will be allowed to assume | `string` | `"arn:aws:iam::955322216602:role/ksoc-connector"` | no |
-| <a name="input_ksoc_secret_key"></a> [ksoc\_secret\_key](#input\_ksoc\_secret\_key) | Ksoc API secret | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = "0.0.1"
+      version = "0.0.3"
     }
   }
 }
@@ -11,14 +11,14 @@ provider "aws" {
   region = "us-west-2"
 }
 
-provider "ksoc" {}
+provider "ksoc" {
+  access_key_id   = var.ksoc_access_key_id
+  ksoc_account_id = var.ksoc_account_id
+  secret_key      = var.ksoc_secret_key
+}
 
 module "ksoc-connect" {
   # https://registry.terraform.io/modules/ksoclabs/ksoc-connect/aws/latest
   source  = "ksoclabs/ksoc-connect/aws"
   version = "<version>"
-
-  ksoc_access_key_id = var.ksoc_access_key_id
-  ksoc_account_id    = var.ksoc_account_id
-  ksoc_secret_key    = var.ksoc_secret_key
 }

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -1,17 +1,14 @@
-variable "ksoc_account_id" {
+variable "ksoc_access_key_id" {
   type        = string
-  default     = "<REDACTED>"
-  description = "Ksoc Account Identifier"
-}
-
-variable "access_key_id" {
-  type        = string
-  default     = "<REDACTED>"
   description = "Ksoc API key"
 }
 
-variable "secret_key" {
+variable "ksoc_account_id" {
   type        = string
-  default     = "<REDACTED>"
+  description = "Ksoc Account Identifier"
+}
+
+variable "ksoc_secret_key" {
+  type        = string
   description = "Ksoc API secret"
 }

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = ">= 0.0.1"
+      version = ">= 0.0.3"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-
-
 # Policy
 data "aws_iam_policy_document" "assume_role" {
   statement {
@@ -36,10 +34,6 @@ resource "aws_iam_instance_profile" "this" {
 }
 
 resource "ksoc_aws_register" "this" {
-  ksoc_api_url          = var.ksoc_api_url
   ksoc_assumed_role_arn = var.ksoc_assumed_role_arn
-  access_key_id         = var.ksoc_access_key_id
-  secret_key            = var.ksoc_secret_key
-  ksoc_account_id       = var.ksoc_account_id
   aws_account_id        = data.aws_caller_identity.current.account_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,26 +1,5 @@
-variable "ksoc_access_key_id" {
-  type        = string
-  description = "Ksoc API key"
-}
-
-variable "ksoc_account_id" {
-  type        = string
-  description = "Ksoc Account Identifier"
-}
-
-variable "ksoc_secret_key" {
-  type        = string
-  description = "Ksoc API secret"
-}
-
 variable "ksoc_assumed_role_arn" {
   type        = string
   description = "KSOC Role that will be allowed to assume"
   default     = "arn:aws:iam::955322216602:role/ksoc-connector"
-}
-
-variable "ksoc_api_url" {
-  type        = string
-  description = "KSOC API to use when registering an account"
-  default     = "https://api.ksoc.com"
 }


### PR DESCRIPTION
The attributes have been moved from resources to the provider in Terraform. This PR updates the module to follow the same pattern. 