### PR TITLE
fix: remove ksoc_account_id from examples

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -12,8 +12,8 @@ provider "aws" {
 }
 
 provider "ksoc" {
-  access_key_id   = var.ksoc_access_key_id
-  secret_key      = var.ksoc_secret_key
+  access_key_id = var.ksoc_access_key_id
+  secret_key    = var.ksoc_secret_key
 }
 
 module "ksoc-connect" {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = "0.0.3"
+      version = "0.0.4"
     }
   }
 }
@@ -13,7 +13,6 @@ provider "aws" {
 
 provider "ksoc" {
   access_key_id   = var.ksoc_access_key_id
-  ksoc_account_id = var.ksoc_account_id
   secret_key      = var.ksoc_secret_key
 }
 

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -3,11 +3,6 @@ variable "ksoc_access_key_id" {
   description = "Ksoc API key"
 }
 
-variable "ksoc_account_id" {
-  type        = string
-  description = "Ksoc Account Identifier"
-}
-
 variable "ksoc_secret_key" {
   type        = string
   description = "Ksoc API secret"

--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -8,7 +8,7 @@ terraform {
 
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = ">= 0.0.3"
+      version = ">= 0.0.4"
     }
   }
 }


### PR DESCRIPTION
Remove ksoc-account-id as its no longer required