### PR TITLE
Add EKS audit logs pipeline resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The module needs an AWS provider to be configured. It will create an IAM Role ca
 
 When the `ksoc-connect` Role is created, it will be added to your KSOC account through the `ksoc_aws_register` resource.
 
+There is an optional flag `enable_eks_audit_logs_pipeline` which will create a CloudWatch Logs -> FireHose -> S3 pipeline for all EKS clusters in the account. This is required for KSOC to be able to analyse EKS audit logs. Make sure to enable EKS audit logs for EKS clusters you wish to be analysed.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -37,6 +39,7 @@ When the `ksoc-connect` Role is created, it will be added to your KSOC account t
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.62.0 |
 | <a name="provider_ksoc"></a> [ksoc](#provider\_ksoc) | >= 0.0.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -46,19 +49,37 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_subscription_filter.subscription_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 | [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.connect_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.ksoc_connect_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kinesis_firehose_delivery_stream.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
+| [aws_s3_bucket.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [ksoc_aws_register.this](https://registry.terraform.io/providers/ksoclabs/ksoc/latest/docs/resources/aws_register) | resource |
+| [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_cloudwatch_log_groups.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudwatch_log_groups) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cloudwatch_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.firehose_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.firehose_to_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ksoc_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.logs_to_firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_eks_audit_logs_pipeline"></a> [enable\_eks\_audit\_logs\_pipeline](#input\_enable\_eks\_audit\_logs\_pipeline) | Enable EKS Audit Logs Pipeline (CloudWatch Logs -> FireHose -> S3) | `bool` | `false` | no |
 | <a name="input_ksoc_assumed_role_arn"></a> [ksoc\_assumed\_role\_arn](#input\_ksoc\_assumed\_role\_arn) | KSOC Role that will be allowed to assume | `string` | `"arn:aws:iam::955322216602:role/ksoc-connector"` | no |
+| <a name="input_ksoc_eks_audit_logs_assumed_role_arn"></a> [ksoc\_eks\_audit\_logs\_assumed\_role\_arn](#input\_ksoc\_eks\_audit\_logs\_assumed\_role\_arn) | KSOC Role dedicated for EKS audit logs that will be allowed to assume | `string` | `"arn:aws:iam::955322216602:role/ksoc-data-pipeline"` | no |
 
 ## Outputs
 

--- a/eks_audit_logs.tf
+++ b/eks_audit_logs.tf
@@ -1,0 +1,162 @@
+locals {
+  bucket_name = "ksoc-eks-${random_id.uniq.hex}"
+}
+
+resource "random_id" "uniq" {
+  byte_length = 4
+}
+
+data "aws_cloudwatch_log_groups" "eks" {
+  count                 = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  log_group_name_prefix = "/aws/eks/"
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "firehose" {
+  count       = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  name        = "ksoc-audit-logs"
+  destination = "extended_s3"
+
+  extended_s3_configuration {
+    role_arn   = aws_iam_role.firehose[0].arn
+    bucket_arn = aws_s3_bucket.audit_logs[0].arn
+
+    buffering_interval = 60
+    buffering_size     = 5 // MiB
+  }
+}
+
+resource "aws_s3_bucket" "audit_logs" {
+  count         = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  bucket        = local.bucket_name
+  force_destroy = true
+  tags = {
+    ksoc-data-type = "eks-audit-logs"
+  }
+}
+
+data "aws_iam_policy_document" "firehose_assume" {
+  count = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "firehose_to_s3" {
+  count = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload", "s3:GetBucketLocation", "s3:GetObject", "s3:ListBucket",
+      "s3:ListBucketMultipartUploads", "s3:PutObject"
+    ]
+    resources = [aws_s3_bucket.audit_logs[0].arn, "${aws_s3_bucket.audit_logs[0].arn}/*"]
+  }
+}
+
+resource "aws_iam_role" "firehose" {
+  count              = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  name               = "ksoc-firehose"
+  assume_role_policy = data.aws_iam_policy_document.firehose_assume[0].json
+  inline_policy {
+    name   = "ksoc-firehose-to-s3-policy"
+    policy = data.aws_iam_policy_document.firehose_to_s3[0].json
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_assume" {
+  count = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "logs_to_firehose" {
+  count = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  statement {
+    effect    = "Allow"
+    actions   = ["firehose:PutRecord"]
+    resources = [aws_kinesis_firehose_delivery_stream.firehose[0].arn]
+  }
+}
+
+resource "aws_iam_role" "cloudwatch" {
+  count              = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  name               = "ksoc-cloudwatch-logs"
+  assume_role_policy = data.aws_iam_policy_document.cloudwatch_assume[0].json
+  inline_policy {
+    name   = "ksoc-cloudwatch-logs-to-firehose-policy"
+    policy = data.aws_iam_policy_document.logs_to_firehose[0].json
+  }
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "subscription_filter" {
+  for_each = var.enable_eks_audit_logs_pipeline ? {
+    for name in data.aws_cloudwatch_log_groups.eks[0].log_group_names : name => name
+  } : {}
+
+  name            = "ksoc-audit-logs"
+  role_arn        = aws_iam_role.cloudwatch[0].arn
+  log_group_name  = each.key
+  filter_pattern  = "{ $.stage = \"ResponseComplete\" && $.requestURI != \"/version\" && $.requestURI != \"/version?*\" && $.requestURI != \"/metrics\" && $.requestURI != \"/metrics?*\" && $.requestURI != \"/logs\" && $.requestURI != \"/logs?*\" && $.requestURI != \"/swagger*\" && $.requestURI != \"/livez*\" && $.requestURI != \"/readyz*\" && $.requestURI != \"/healthz*\" }"
+  destination_arn = aws_kinesis_firehose_delivery_stream.firehose[0].arn
+  distribution    = "Random"
+}
+
+# Cross-account connectivity.
+data "aws_iam_policy_document" "ksoc_s3_access" {
+  count = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject", "s3:ListBucket"
+    ]
+    resources = [aws_s3_bucket.audit_logs[0].arn, "${aws_s3_bucket.audit_logs[0].arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "ksoc_s3_access" {
+  count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  policy = data.aws_iam_policy_document.ksoc_s3_access[0].json
+}
+
+data "aws_iam_policy_document" "ksoc_assume" {
+  count = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.ksoc_eks_audit_logs_assumed_role_arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "ksoc_s3_access" {
+  count                = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  name                 = "ksoc-audit-logs"
+  path                 = "/"
+  max_session_duration = 3600
+
+  assume_role_policy = data.aws_iam_policy_document.ksoc_assume[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "ksoc_s3_access" {
+  count      = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  role       = aws_iam_role.ksoc_s3_access[0].name
+  policy_arn = aws_iam_policy.ksoc_s3_access[0].arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,15 @@ variable "ksoc_assumed_role_arn" {
   description = "KSOC Role that will be allowed to assume"
   default     = "arn:aws:iam::955322216602:role/ksoc-connector"
 }
+
+variable "enable_eks_audit_logs_pipeline" {
+  type        = bool
+  description = "Enable EKS Audit Logs Pipeline (CloudWatch Logs -> FireHose -> S3)"
+  default     = false
+}
+
+variable "ksoc_eks_audit_logs_assumed_role_arn" {
+  type        = string
+  description = "KSOC Role dedicated for EKS audit logs that will be allowed to assume"
+  default     = "arn:aws:iam::955322216602:role/ksoc-data-pipeline"
+}


### PR DESCRIPTION
Optional resources for audit logs analysis can be created when `enable_eks_audit_logs_pipeline` is set to `true`. It will create necessary roles, CloudWatch Logs filters, FireHose and S3 bucket.