### PR TITLE
More recent AWS provider is needed for EKS Audit Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ There is an optional flag `enable_eks_audit_logs_pipeline` which will create a C
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.62.0 |
-| <a name="requirement_ksoc"></a> [ksoc](#requirement\_ksoc) | >= 0.0.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
+| <a name="requirement_ksoc"></a> [ksoc](#requirement\_ksoc) | >= 0.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.62.0 |
-| <a name="provider_ksoc"></a> [ksoc](#provider\_ksoc) | >= 0.0.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_ksoc"></a> [ksoc](#provider\_ksoc) | >= 0.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.62.0"
+      version = ">= 5.0.0"
     }
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = ">= 0.0.1"
+      version = ">= 0.1.0"
     }
   }
 }


### PR DESCRIPTION
Kinesis Firehose parameters `buffering_interval` and `buffering_size` were renamed in 5.0.0.