### PR TITLE
Enable versioning for audit logs bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ No modules.
 | [aws_iam_role_policy_attachment.ksoc_s3_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kinesis_firehose_delivery_stream.firehose](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_firehose_delivery_stream) | resource |
 | [aws_s3_bucket.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_versioning.audit_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [ksoc_aws_register.this](https://registry.terraform.io/providers/ksoclabs/ksoc/latest/docs/resources/aws_register) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/eks_audit_logs.tf
+++ b/eks_audit_logs.tf
@@ -34,6 +34,14 @@ resource "aws_s3_bucket" "audit_logs" {
   }
 }
 
+resource "aws_s3_bucket_versioning" "audit_logs" {
+  count  = var.enable_eks_audit_logs_pipeline ? 1 : 0
+  bucket = aws_s3_bucket.audit_logs[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
 data "aws_iam_policy_document" "firehose_assume" {
   count = var.enable_eks_audit_logs_pipeline ? 1 : 0
   statement {


### PR DESCRIPTION
This is to satisfy any pottential compliance checks. Versioning is not really used by FireHose.