### PR TITLE
Add support for multi-region EKS audit logs pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ The module needs an AWS provider to be configured. It will create an IAM Role in
 
 When the `ksoc-connect` Role is created, it will be added to your KSOC account through the `ksoc_aws_register` resource.
 
-There is an optional flag `enable_eks_audit_logs_pipeline` which will create a CloudWatch Logs -> FireHose -> S3 pipeline for all EKS clusters in the account. This is required for KSOC to be able to analyse EKS audit logs. Make sure to enable EKS audit logs for EKS clusters you wish to be analysed.
+### EKS Audit Logs
+
+There is an optional flag `enable_eks_audit_logs_pipeline` which will create a CloudWatch Logs -> FireHose -> S3 pipeline for all EKS clusters in the account. This is required for KSOC to be able to analyse EKS audit logs. Make sure to enable EKS audit logs for EKS clusters you wish to be analysed. By default, the pipeline creates policy for CloudWatch in all four US regions. If you have EKS clusters in other regions, you can override the `eks_audit_logs_regions` variable.
+
+Also, only clusters in the same region as your AWS provider will be included in the pipeline. If you have EKS clusters in multiple regions, you need to enable `eks_audit_logs_multi_region` flag and create subscription filters in each region outside of this module (see example in the [eks-audit-logs-multi-region](https://github.com/ksoclabs/terraform-aws-ksoc-connect/tree/main/examples/eks-audit-logs-multi-region) directory).
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -79,6 +83,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_eks_audit_logs_bucket_versioning_enabled"></a> [eks\_audit\_logs\_bucket\_versioning\_enabled](#input\_eks\_audit\_logs\_bucket\_versioning\_enabled) | Enable versioning for the S3 bucket that will store EKS audit logs | `bool` | `true` | no |
+| <a name="input_eks_audit_logs_filter_pattern"></a> [eks\_audit\_logs\_filter\_pattern](#input\_eks\_audit\_logs\_filter\_pattern) | The Cloudwatch Log Subscription Filter pattern | `string` | `"{ $.stage = \"ResponseComplete\" && $.requestURI != \"/version\" && $.requestURI != \"/version?*\" && $.requestURI != \"/metrics\" && $.requestURI != \"/metrics?*\" && $.requestURI != \"/logs\" && $.requestURI != \"/logs?*\" && $.requestURI != \"/swagger*\" && $.requestURI != \"/livez*\" && $.requestURI != \"/readyz*\" && $.requestURI != \"/healthz*\" }"` | no |
+| <a name="input_eks_audit_logs_multi_region"></a> [eks\_audit\_logs\_multi\_region](#input\_eks\_audit\_logs\_multi\_region) | Enable multi-region support for the EKS audit logs. This requires creating subscription filters in each region outside of this module. See documentation for more information. | `bool` | `false` | no |
+| <a name="input_eks_audit_logs_regions"></a> [eks\_audit\_logs\_regions](#input\_eks\_audit\_logs\_regions) | Regions from which Cloudwatch will be allowed to send logs to the Firehose | `list(string)` | <pre>[<br>  "us-east-1",<br>  "us-east-2",<br>  "us-west-1",<br>  "us-west-2"<br>]</pre> | no |
 | <a name="input_enable_eks_audit_logs_pipeline"></a> [enable\_eks\_audit\_logs\_pipeline](#input\_enable\_eks\_audit\_logs\_pipeline) | Enable EKS Audit Logs Pipeline (CloudWatch Logs -> FireHose -> S3) | `bool` | `false` | no |
 | <a name="input_ksoc_assumed_role_arn"></a> [ksoc\_assumed\_role\_arn](#input\_ksoc\_assumed\_role\_arn) | KSOC Role that will assume the ksoc-connect IAM role you create to interact with resources in your account | `string` | `"arn:aws:iam::955322216602:role/ksoc-connector"` | no |
 | <a name="input_ksoc_eks_audit_logs_assumed_role_arn"></a> [ksoc\_eks\_audit\_logs\_assumed\_role\_arn](#input\_ksoc\_eks\_audit\_logs\_assumed\_role\_arn) | KSOC Role dedicated for EKS audit logs that will be allowed to assume | `string` | `"arn:aws:iam::955322216602:role/ksoc-data-pipeline"` | no |
@@ -87,6 +94,9 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_eks_audit_logs_cloudwatch_iam_role_arn"></a> [eks\_audit\_logs\_cloudwatch\_iam\_role\_arn](#output\_eks\_audit\_logs\_cloudwatch\_iam\_role\_arn) | AWS IAM Role ARN for Cloudwatch to Firehose |
+| <a name="output_eks_audit_logs_filter_pattern"></a> [eks\_audit\_logs\_filter\_pattern](#output\_eks\_audit\_logs\_filter\_pattern) | The Cloudwatch Log Subscription Filter pattern |
+| <a name="output_eks_audit_logs_firehose_arn"></a> [eks\_audit\_logs\_firehose\_arn](#output\_eks\_audit\_logs\_firehose\_arn) | The Firehose delivery stream ARN |
 | <a name="output_role_arn"></a> [role\_arn](#output\_role\_arn) | AWS IAM Role ARN which Ksoc uses to connect |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/audit_logs/main.tf
+++ b/examples/audit_logs/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = "0.0.4"
+      version = "0.1.0"
     }
   }
 }
@@ -20,4 +20,6 @@ module "ksoc-connect" {
   # https://registry.terraform.io/modules/ksoclabs/ksoc-connect/aws/latest
   source  = "ksoclabs/ksoc-connect/aws"
   version = "<version>"
+
+  enable_eks_audit_logs_pipeline = true
 }

--- a/examples/audit_logs/variables.tf
+++ b/examples/audit_logs/variables.tf
@@ -1,9 +1,9 @@
 variable "ksoc_access_key_id" {
   type        = string
-  description = "Ksoc API key"
+  description = "KSOC API key"
 }
 
 variable "ksoc_secret_key" {
   type        = string
-  description = "Ksoc API secret"
+  description = "KSOC API secret"
 }

--- a/examples/audit_logs/versions.tf
+++ b/examples/audit_logs/versions.tf
@@ -3,12 +3,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.11.0"
+      version = ">= 5.0.0"
     }
 
     ksoc = {
       source  = "ksoclabs/ksoc"
-      version = ">= 0.0.4"
+      version = ">= 0.1.0"
     }
   }
 }

--- a/examples/audit_logs_multi_region/main.tf
+++ b/examples/audit_logs_multi_region/main.tf
@@ -1,0 +1,70 @@
+terraform {
+  required_providers {
+    ksoc = {
+      source  = "ksoclabs/ksoc"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "us-west-2"
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+provider "ksoc" {
+  access_key_id = var.ksoc_access_key_id
+  secret_key    = var.ksoc_secret_key
+}
+
+module "ksoc-connect" {
+  providers = {
+    aws = aws.us-west-2
+  }
+
+  # https://registry.terraform.io/modules/ksoclabs/ksoc-connect/aws/latest
+  source  = "ksoclabs/ksoc-connect/aws"
+  version = "<version>"
+
+  enable_eks_audit_logs_pipeline = true
+  eks_audit_logs_multi_region    = true
+}
+
+data "aws_cloudwatch_log_groups" "ksoc-cw-log-groups-us-west-2" {
+  provider              = aws.us-west-2
+  log_group_name_prefix = "/aws/eks/"
+}
+
+data "aws_cloudwatch_log_groups" "ksoc-cw-log-groups-us-east-1" {
+  provider              = aws.us-east-1
+  log_group_name_prefix = "/aws/eks/"
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "ksoc-subscription-filter-us-west-2" {
+  for_each = { for name in data.aws_cloudwatch_log_groups.ksoc-cw-log-groups-us-west-2.log_group_names : name => name }
+  provider = aws.us-west-2
+
+  name            = "ksoc-audit-logs"
+  role_arn        = module.ksoc-connect.eks_audit_logs_cloudwatch_iam_role_arn
+  log_group_name  = each.value
+  filter_pattern  = module.ksoc-connect.eks_audit_logs_filter_pattern
+  destination_arn = module.ksoc-connect.eks_audit_logs_firehose_arn
+  depends_on      = [module.ksoc-connect]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "ksoc-subscription-filter-us-east-1" {
+  for_each = { for name in data.aws_cloudwatch_log_groups.ksoc-cw-log-groups-us-east-1.log_group_names : name => name }
+  provider = aws.us-east-1
+
+  name            = "ksoc-audit-logs"
+  role_arn        = module.ksoc-connect.eks_audit_logs_cloudwatch_iam_role_arn
+  log_group_name  = each.value
+  filter_pattern  = module.ksoc-connect.eks_audit_logs_filter_pattern
+  destination_arn = module.ksoc-connect.eks_audit_logs_firehose_arn
+  depends_on      = [module.ksoc-connect]
+}

--- a/examples/audit_logs_multi_region/variables.tf
+++ b/examples/audit_logs_multi_region/variables.tf
@@ -1,0 +1,9 @@
+variable "ksoc_access_key_id" {
+  type        = string
+  description = "KSOC API key"
+}
+
+variable "ksoc_secret_key" {
+  type        = string
+  description = "KSOC API secret"
+}

--- a/examples/audit_logs_multi_region/versions.tf
+++ b/examples/audit_logs_multi_region/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+
+    ksoc = {
+      source  = "ksoclabs/ksoc"
+      version = ">= 0.1.0"
+    }
+  }
+}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ksoc = {
+      source  = "ksoclabs/ksoc"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "ksoc" {
+  access_key_id = var.ksoc_access_key_id
+  secret_key    = var.ksoc_secret_key
+}
+
+module "ksoc-connect" {
+  # https://registry.terraform.io/modules/ksoclabs/ksoc-connect/aws/latest
+  source  = "ksoclabs/ksoc-connect/aws"
+  version = "<version>"
+}

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,0 +1,9 @@
+variable "ksoc_access_key_id" {
+  type        = string
+  description = "KSOC API key"
+}
+
+variable "ksoc_secret_key" {
+  type        = string
+  description = "KSOC API secret"
+}

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+
+    ksoc = {
+      source  = "ksoclabs/ksoc"
+      version = ">= 0.1.0"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,18 @@ output "role_arn" {
   value       = aws_iam_role.this.arn
   description = "AWS IAM Role ARN which Ksoc uses to connect"
 }
+
+output "eks_audit_logs_cloudwatch_iam_role_arn" {
+  value       = var.enable_eks_audit_logs_pipeline ? aws_iam_role.cloudwatch[0].arn : ""
+  description = "AWS IAM Role ARN for Cloudwatch to Firehose"
+}
+
+output "eks_audit_logs_filter_pattern" {
+  value       = var.eks_audit_logs_filter_pattern
+  description = "The Cloudwatch Log Subscription Filter pattern"
+}
+
+output "eks_audit_logs_firehose_arn" {
+  value       = var.enable_eks_audit_logs_pipeline ? aws_kinesis_firehose_delivery_stream.firehose[0].arn : ""
+  description = "The Firehose delivery stream ARN"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,21 @@ variable "ksoc_eks_audit_logs_assumed_role_arn" {
   description = "KSOC Role dedicated for EKS audit logs that will be allowed to assume"
   default     = "arn:aws:iam::955322216602:role/ksoc-data-pipeline"
 }
+
+variable "eks_audit_logs_filter_pattern" {
+  type        = string
+  default     = "{ $.stage = \"ResponseComplete\" && $.requestURI != \"/version\" && $.requestURI != \"/version?*\" && $.requestURI != \"/metrics\" && $.requestURI != \"/metrics?*\" && $.requestURI != \"/logs\" && $.requestURI != \"/logs?*\" && $.requestURI != \"/swagger*\" && $.requestURI != \"/livez*\" && $.requestURI != \"/readyz*\" && $.requestURI != \"/healthz*\" }"
+  description = "The Cloudwatch Log Subscription Filter pattern"
+}
+
+variable "eks_audit_logs_regions" {
+  type        = list(string)
+  default     = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
+  description = "Regions from which Cloudwatch will be allowed to send logs to the Firehose"
+}
+
+variable "eks_audit_logs_multi_region" {
+  type        = bool
+  default     = false
+  description = "Enable multi-region support for the EKS audit logs. This requires creating subscription filters in each region outside of this module. See documentation for more information."
+}


### PR DESCRIPTION
To gather EKS audit logs from multiple regions, some extra steps are required. This change
adds support for all US regions by default and allows to provide own subscription resources
for different regions. See `examples/audit_logs_multi_region` and README.md for details.