### PR TITLE
Add sts:TagSession to ksoc-connect Role Policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,11 @@
 # Policy
 data "aws_iam_policy_document" "assume_role" {
   statement {
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
 
     principals {
       type        = "AWS"


### PR DESCRIPTION
We need `sts:TagSession` as well as `sts:AssumeRole` to extend the number of ways we can assume the `ksoc-connect` AWS Role. 